### PR TITLE
Optional parameter to surround

### DIFF
--- a/src/string.utils.js
+++ b/src/string.utils.js
@@ -720,7 +720,7 @@ export {shuffle};
  * @param substr
  * @return string
  */
-const surround = (value, _substr = '') => append(_substr, value, _substr);
+const surround = (value, _substr = '', _substrRight = null) => append(_substr, value, _substrRight === null ? _substr : _substrRight);
 
 export {surround};
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -838,6 +838,7 @@ describe('surround function', () => {
         chai.expect(surround('', '>')).to.equal('>>');
         chai.expect(surround('bar', '')).to.equal('bar');
         chai.expect(surround('f')).to.equal('f');
+        chai.expect(surround('div','<','>')).to.equal('<div>');
     });
 });
 


### PR DESCRIPTION
This is a suggestion - adding a third, optional, parameter to the surround function, to be able to append a different substring to the right of the value. To be used with, for example:

- `<tags>`
- “fancy quotes”
- «guillemets»

etc.